### PR TITLE
adds pretty show for decision branches, with test

### DIFF
--- a/src/decision_tree.jl
+++ b/src/decision_tree.jl
@@ -236,3 +236,16 @@ function Base.show(io::IO, tree::ClassificationTree)
                  @sprintf("    %d Classes",length(tree.classes))], "\n")
     print(io, info)
 end
+
+Base.show(io::IO, branch::DecisionBranch) = print(io, pretty_string(branch, 1))
+pretty_string(leaf::DecisionLeaf, indent::Integer) = string(leaf)
+function pretty_string(branch::DecisionBranch, indent::Integer) 
+    @sprintf("DecisionBranch(%d, %f, \n%s%s \n%s%s)", 
+    branch.feature,
+    branch.value,
+    repeat("|", indent), 
+    pretty_string(branch.left, indent+1), 
+    repeat("|", indent), 
+    pretty_string(branch.right, indent+1))
+end
+pretty_string(branch::DecisionBranch) = pretty_string(branch::DecisionBranch, 1)

--- a/test/decision_tree.jl
+++ b/test/decision_tree.jl
@@ -51,3 +51,13 @@ for i=1:10
 end
 println("Linear Pearson Correlation: ", mean(correlations))
 @test mean(correlations)>0.50
+
+branch = DecisionBranch(1, 0.5, 
+	DecisionBranch(2, 1.5, 
+		DecisionBranch(3, 2.5, 
+			MachineLearning.RegressionLeaf(10.0), 
+			MachineLearning.RegressionLeaf(12.0)),
+		MachineLearning.RegressionLeaf(20.0)), 
+	MachineLearning.RegressionLeaf(30.0))
+
+@test MachineLearning.pretty_string(branch) == "DecisionBranch(1, 0.500000, \n|DecisionBranch(2, 1.500000, \n||DecisionBranch(3, 2.500000, \n|||RegressionLeaf(10.0) \n|||RegressionLeaf(12.0)) \n||RegressionLeaf(20.0)) \n|RegressionLeaf(30.0))"


### PR DESCRIPTION
This adds a nicer `show` method for `DecisionBranch`. So instead of getting:

```
DecisionBranch(1,0.5,DecisionBranch(2,1.5,DecisionBranch(3,2.5,RegressionLeaf(10.0),RegressionLeaf(12.0)),RegressionLeaf(20.0)),RegressionLeaf(30.0))
```

... you get:

```
DecisionBranch(1, 0.500000, 
|DecisionBranch(2, 1.500000, 
||DecisionBranch(3, 2.500000, 
|||RegressionLeaf(10.0) 
|||RegressionLeaf(12.0)) 
||RegressionLeaf(20.0)) 
|RegressionLeaf(30.0))
```

But it's possible the output of this will too many lines for you to want it as a default `show` method, though.

I also might not have thought through every case, so it's possible this isn't general enough? Anyway, won't be offended if you think this doesn't belong in the package, but here it is if you want it.
